### PR TITLE
Implement PRISMA_Save()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,8 @@ Imports:
     shinyjs,
     stats,
     stringr,
-    utils
+    utils,
+    xml2
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,9 @@ Imports:
     stats,
     stringr,
     utils,
-    xml2
+    xml2,
+    webp,
+    tools
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/R/PRISMA_flowdiagram.R
+++ b/R/PRISMA_flowdiagram.R
@@ -765,7 +765,9 @@ PRISMA_save <- function(plotobj, format = 'HTML', filename = 'PRISMA2020_flowdia
     },
     "SVG" = {
       tmp_svg <- gen_tmp_svg_(plotobj)
-      xml2::write_xml(tmp_svg,file = paste0(filename,'.svg'))
+      if (!(file.copy(tmp_svg, paste0(filename,'.svg'), overwrite = TRUE))){
+        stop("Error saving SVG")
+      }
     },
     "PS" = {
       tmp_svg <- gen_tmp_svg_(plotobj)

--- a/R/PRISMA_flowdiagram.R
+++ b/R/PRISMA_flowdiagram.R
@@ -689,7 +689,7 @@ sr_flow_interactive <- function(plot,
 #' working directory.
 #' @param plotobj A plot produced using PRISMA_flowdiagram().
 #' @param format The format to save the plot in, supports: HTML, PDF, PNG, SVG, PS and WEBP
-#' @param filename The filename to save 
+#' @param filename The filename to save (without extension)
 #' @return A flow diagram plot as an html file, with embedded links and 
 #' tooltips if interactive=TRUE in PRISMA_flowdiagram() and if tooltips 
 #' are provided in the data upload, respectively.
@@ -765,7 +765,7 @@ PRISMA_save <- function(plotobj, format = 'HTML', filename = 'PRISMA2020_flowdia
     },
     "SVG" = {
       tmp_svg <- gen_tmp_svg_(plotobj)
-      rsvg::rsvg_svg(tmp_svg, paste0(filename,'.svg'))
+      xml2::write_xml(tmp_svg,paste0(filename,'.svg'))
     },
     "PS" = {
       tmp_svg <- gen_tmp_svg_(plotobj)

--- a/R/PRISMA_flowdiagram.R
+++ b/R/PRISMA_flowdiagram.R
@@ -61,12 +61,25 @@ PRISMA_flowdiagram <- function (data,
                                 arrow_head = 'normal',
                                 arrow_tail = 'none') {
   
+  add_newline_between_chars_ <- function(x) {
+    return(gsub("(.)(?!$)", "\\1\n", x, perl=TRUE))
+  }
+
+  id_side_label='Identification'
+  scr_side_label='Screening'
+  inc_side_label='Included'
+
+  id_side_label <- add_newline_between_chars_(id_side_label)
+  scr_side_label <- add_newline_between_chars_(scr_side_label)
+  inc_side_label <- add_newline_between_chars_(inc_side_label)
+  
+
   #wrap exclusion reasons
   dbr_excluded[,1] <- stringr::str_wrap(dbr_excluded[,1], 
                     width = 35)
   other_excluded[,1] <- stringr::str_wrap(other_excluded[,1], 
                     width = 35)
-  
+
   if(stringr::str_count(paste(dbr_excluded[,1], collapse = "\n"), "\n") > 3){
     dbr_excludedh <- 3.5 - ((stringr::str_count(paste(dbr_excluded[,1], collapse = "\n"), "\n")-4)/9)
   } else {
@@ -272,10 +285,14 @@ PRISMA_flowdiagram <- function (data,
   
   graph[splines=ortho, layout=neato, tooltip = 'Click the boxes for further information', outputorder=edgesfirst]
   
-  node [shape = box]
-  identification [color = LightSteelBlue2, label='', style = 'filled,rounded', pos='",-1.4,",",ystart+7,"!', width = 0.4, height = 1.5, tooltip = '", tooltips[20], "'];
-  screening [color = LightSteelBlue2, label='', style = 'filled,rounded', pos='",-1.4,",",ystart+4.5,"!', width = 0.4, height = 2.5, tooltip = '", tooltips[21], "'];
-  included [color = LightSteelBlue2, label='', style = 'filled,rounded', pos='",-1.4,",",h_adj1+0.87,"!', width = 0.4, height = ",2.5-h_adj2,", tooltip = '", tooltips[22], "'];\n
+  node [shape = box,
+        fontsize = ", fontsize,",
+        fontname = ", font, ",
+        color = ", title_colour, ",
+        labelangle = 90 ]
+  identification [color = LightSteelBlue2, label='",id_side_label,"', style = 'filled,rounded', pos='",-1.4,",",ystart+7,"!', width = 0.4, height = 1.5, tooltip = '", tooltips[20], "'];
+  screening [color = LightSteelBlue2, label='",scr_side_label,"', style = 'filled,rounded', pos='",-1.4,",",ystart+4.5,"!', width = 0.4, height = 2.5, tooltip = '", tooltips[21], "'];
+  included [color = LightSteelBlue2, label='",inc_side_label,"', style = 'filled,rounded', pos='",-1.4,",",h_adj1+0.87,"!', width = 0.4, height = ",2.5-h_adj2,", tooltip = '", tooltips[22], "'];\n
   ",
            previous_nodes,"
   node [shape = box,
@@ -436,60 +453,60 @@ PRISMA_flowdiagram <- function (data,
   ")
   )
   
-  # Append in vertical text on blue bars
-  if (paste0(previous,  other) == 'TRUETRUE'){
-    insertJS <- function(plot){
-      javascript <- htmltools::HTML('
-var theDiv = document.getElementById("node1");
-theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'537\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Identification</text>";
-var theDiv = document.getElementById("node2");
-theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'356\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Screening</text>";
-var theDiv = document.getElementById("node3");
-theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'95\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Included</text>";
-                              ')
-      htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
-    }
-    x <- insertJS(x)
-    } else if (paste0(previous,  other) == 'FALSETRUE'){
-    insertJS <- function(plot){
-      javascript <- htmltools::HTML('
-var theDiv = document.getElementById("node1");
-theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'497\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Identification</text>";
-var theDiv = document.getElementById("node2");
-theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'315\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Screening</text>";
-var theDiv = document.getElementById("node3");
-theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'100\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Included</text>";
-                              ')
-      htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
-    }
-    x <- insertJS(x)
-  } else if (paste0(previous,  other) == 'TRUEFALSE'){
-    insertJS <- function(plot){
-      javascript <- htmltools::HTML('
-var theDiv = document.getElementById("node1");
-theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'536\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Identification</text>";
-var theDiv = document.getElementById("node2");
-theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'357\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Screening</text>";
-var theDiv = document.getElementById("node3");
-theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'95\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Included</text>";
-                              ')
-      htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
-    }
-    x <- insertJS(x)
-  } else {
-    insertJS <- function(plot){
-      javascript <- htmltools::HTML('
-var theDiv = document.getElementById("node1");
-theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'497\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Identification</text>";
-var theDiv = document.getElementById("node2");
-theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'315\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Screening</text>";
-var theDiv = document.getElementById("node3");
-theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'100\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Included</text>";
-                              ')
-      htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
-    }
-    x <- insertJS(x)
-    }
+#   # Append in vertical text on blue bars
+#   if (paste0(previous,  other) == 'TRUETRUE'){
+#     insertJS <- function(plot){
+#       javascript <- htmltools::HTML('
+# var theDiv = document.getElementById("node1");
+# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'537\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Identification</text>";
+# var theDiv = document.getElementById("node2");
+# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'356\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Screening</text>";
+# var theDiv = document.getElementById("node3");
+# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'95\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Included</text>";
+#                               ')
+#       htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
+#     }
+#     x <- insertJS(x)
+#     } else if (paste0(previous,  other) == 'FALSETRUE'){
+#     insertJS <- function(plot){
+#       javascript <- htmltools::HTML('
+# var theDiv = document.getElementById("node1");
+# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'497\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Identification</text>";
+# var theDiv = document.getElementById("node2");
+# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'315\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Screening</text>";
+# var theDiv = document.getElementById("node3");
+# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'100\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Included</text>";
+#                               ')
+#       htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
+#     }
+#     x <- insertJS(x)
+#   } else if (paste0(previous,  other) == 'TRUEFALSE'){
+#     insertJS <- function(plot){
+#       javascript <- htmltools::HTML('
+# var theDiv = document.getElementById("node1");
+# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'536\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Identification</text>";
+# var theDiv = document.getElementById("node2");
+# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'357\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Screening</text>";
+# var theDiv = document.getElementById("node3");
+# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'95\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Included</text>";
+#                               ')
+#       htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
+#     }
+#     x <- insertJS(x)
+#   } else {
+#     insertJS <- function(plot){
+#       javascript <- htmltools::HTML('
+# var theDiv = document.getElementById("node1");
+# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'497\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Identification</text>";
+# var theDiv = document.getElementById("node2");
+# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'315\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Screening</text>";
+# var theDiv = document.getElementById("node3");
+# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'100\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Included</text>";
+#                               ')
+#       htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
+#     }
+#     x <- insertJS(x)
+#     }
   
   if (interactive == TRUE) {
     x <- sr_flow_interactive(x, urls, previous = previous, other = other)

--- a/R/PRISMA_flowdiagram.R
+++ b/R/PRISMA_flowdiagram.R
@@ -14,7 +14,7 @@
 #' studies were sought.
 #' @param other Logical argument (TRUE or FALSE) specifying whether other studies 
 #' were sought.
-#' @param font Theor text in each box. The default is 'Helvetica'.
+#' @param font The font for text in each box. The default is 'Helvetica'.
 #' @param fontsize The font size for text in each box. The default is '12'.
 #' @param title_colour The colour for the upper middle title box (new studies). 
 #' The default is 'Goldenrod1'. See 'DiagrammeR' colour scheme 
@@ -61,17 +61,9 @@ PRISMA_flowdiagram <- function (data,
                                 arrow_head = 'normal',
                                 arrow_tail = 'none') {
   
-  add_newline_between_chars_ <- function(x) {
-    return(gsub("(.)(?!$)", "\\1\n", x, perl=TRUE))
-  }
-
   id_side_label <- "Identification"
   scr_side_label <- "Screening"
   inc_side_label <- "Included"
-
-  #id_side_label <- add_newline_between_chars_(id_side_label)
-  #scr_side_label <- add_newline_between_chars_(scr_side_label)
-  #inc_side_label <- add_newline_between_chars_(inc_side_label)
   
   #wrap exclusion reasons
   dbr_excluded[,1] <- stringr::str_wrap(dbr_excluded[,1], 
@@ -117,7 +109,7 @@ PRISMA_flowdiagram <- function (data,
     h_adj2 <- 0
     previous_nodes <- paste0("node [shape = box,
           fontsize = ", fontsize,",
-          fontname = ", font, ",
+          fontname = ", font,",
           color = ", greybox_colour, "]
     1 [label = '", previous_text, "', style = 'rounded,filled', width = 3.5, height = 0.5, pos='",xstart+1,",",ystart+8.25,"!', tooltip = '", tooltips[1], "']
     
@@ -289,9 +281,9 @@ PRISMA_flowdiagram <- function (data,
         fontname = ", font, ",
         color = ", title_colour, "
         ]
-  identification [color = LightSteelBlue2, label='', style = 'filled,rounded', pos='",-1.4,",",ystart+7,"!', width = 0.4, height = 1.5, tooltip = '", tooltips[20], "'];
-  screening [color = LightSteelBlue2, label='', style = 'filled,rounded', pos='",-1.4,",",ystart+4.5,"!', width = 0.4, height = 2.5, tooltip = '", tooltips[21], "'];
-  included [color = LightSteelBlue2, label='', style = 'filled,rounded', pos='",-1.4,",",h_adj1+0.87,"!', width = 0.4, height = ",2.5-h_adj2,", tooltip = '", tooltips[22], "'];\n
+  identification [color = LightSteelBlue2, label=' ', style = 'filled,rounded', pos='",-1.4,",",ystart+7,"!', width = 0.4, height = 1.5, tooltip = '", tooltips[20], "'];
+  screening [color = LightSteelBlue2, label=' ', style = 'filled,rounded', pos='",-1.4,",",ystart+4.5,"!', width = 0.4, height = 2.5, tooltip = '", tooltips[21], "'];
+  included [color = LightSteelBlue2, label=' ', style = 'filled,rounded', pos='",-1.4,",",h_adj1+0.87,"!', width = 0.4, height = ",2.5-h_adj2,", tooltip = '", tooltips[22], "'];\n
   ",
            previous_nodes,"
   node [shape = box,
@@ -451,48 +443,24 @@ PRISMA_flowdiagram <- function (data,
   }
   ")
   )
-  
-  # Append in vertical text on blue bars
-  switch (
-    paste0(previous, other),
-    'TRUETRUE' = {
-      y = '19'
-      node1x <- '537'
-      node2x <- '356'
-      node3x <- '95'
-    },
-    'FALSETRUE' = {
-      y = '19'
-      node1x <- '497'
-      node2x <- '315'
-      node3x <- '100'
-    },
-    'TRUEFALSE' = {
-      y = '19'
-      node1x <- '536'
-      node2x <- '357'
-      node3x <- '95'
-    },
-    'FALSEFALSE' = {
-      y = '19'
-      node1x <- '440'
-      node2x <- '260'
-      node3x <- '40'
-    }
-  )
 
   insertJS_ <- function (plot) {
-    javascript <- htmltools::HTML(paste0('
-      var theDiv = document.getElementById("node1");
-      theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'',node1x,'\' y=\'',y,'\' font-family=\'',font,',sans-Serif\' font-size=\'',fontsize,'\'>',id_side_label,'</text>";
-      var theDiv = document.getElementById("node2");
-      theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'',node2x,'\' y=\'',y,'\' font-family=\'',font,',sans-Serif\' font-size=\'',fontsize,'\'>',scr_side_label,'</text>";
-      var theDiv = document.getElementById("node3");
-      theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'',node3x,'\' y=\'',y,'\' font-family=\'',font,',sans-Serif\' font-size=\'',fontsize,'\'>',inc_side_label,'</text>";
-    '))
-    htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
-  }
-  x <- insertJS_(x)
+     javascript <- htmltools::HTML(paste0('
+        const nodeMap = new Map([["node1","',id_side_label,'"], ["node2","',scr_side_label,'"], ["node3","',inc_side_label,'"]]);
+        for (const [node, label] of nodeMap) {
+          var theDiv = document.getElementById(node);
+          var theText = theDiv.querySelector("text");
+          var attrX = theText.getAttribute("x");
+          var attrY = theText.getAttribute("y");
+          theText.setAttribute("y",1+parseFloat(attrX))
+          theText.setAttribute("x",-1*parseFloat(attrY))
+          theText.setAttribute("style","transform: rotate(-90deg);")
+          theText.innerHTML = label;
+        }
+     '))
+     htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
+   }
+   x <- insertJS_(x)
   
   if (interactive == TRUE) {
     x <- sr_flow_interactive(x, urls, previous = previous, other = other)
@@ -740,14 +708,45 @@ sr_flow_interactive <- function(plot,
 #' @export
 PRISMA_save <- function(plotobj, format = 'HTML', filename = 'PRISMA2020_flowdiagram'){
   gen_tmp_svg_ <- function(obj) {
-    #xpathsvg = "//*[name() = 'svg']"
+    # generate temporary filenames
     tmpfilehtml <- tempfile(pattern = "PRISMA2020_", tmpdir = tempdir(), fileext = ".html" )
     tmpfilesvg <- tempfile(pattern = "PRISMA2020_", tmpdir = tempdir(), fileext = ".svg" )
+    # save the widget as HTML and read it into a variable
     htmlwidgets::saveWidget(obj, file=tmpfilehtml)
     htmldata <- xml2::read_html(tmpfilehtml)
-    js <- xml2::xml_find_first(htmldata,'//div[contains(@class, "grViz")]//following-sibling::script')    
+    # extract our labelling javascript using xml_find_first and xpath
+    # it finds the first script element follwing the grViz class - this looks to be quite fragile if we change our injected JS
+    js <- xml2::xml_text(xml2::xml_find_first(htmldata,'//div[contains(@class, "grViz")]//following-sibling::script'))
+    # use DiagrammeRsvg to export an SVG from the htmlwidgets code - this uses the V8 engine in the background so takes a little bit of time to run
+    # then read the SVG's XML into a variable
     svg <- DiagrammeRsvg::export_svg(plotobj)
-    writeLines(svg,tmpfilesvg)
+    svg <- xml2::read_xml(svg)
+    # we need to extract the node names and the label values from our JS, so find the appropriate part of the code (again, sensitive to script changes)
+    # we then extract the node names and labels and insert them into the SVG, in a similar manner to the original JS code
+    jsnode <- stringr::str_split(
+      stringr::str_remove_all(
+        stringr::str_match(
+          js, "const nodeMap = new Map\\(\\[(.*)\\]\\);"
+        )[1,2],
+        "\\[|\"|]"
+      ),
+      ",\\s",
+      simplify = TRUE
+    )
+    len <- length(jsnode)
+    for (i in 1:len) {
+      matsp <- stringr::str_split_fixed(jsnode[i],",",2)
+      namespace <- xml2::xml_ns(svg)
+      xml_text_node <- xml2::xml_find_first(svg, paste0('//d1:g[@id="',matsp[,1],'"]//d1:text'), namespace)
+      attrX <- xml2::xml_attr(xml_text_node, "x")
+      attrY <- xml2::xml_attr(xml_text_node, "y")
+      xml2::xml_attr(xml_text_node, "x") <- as.double(attrY)*-1
+      xml2::xml_attr(xml_text_node, "y") <- as.double(attrX)+1
+      # libRSVG does not support css transforms, so we need to use the native SVG transform attribute
+      xml2::xml_attr(xml_text_node, "transform") <- "rotate(-90)"
+      xml2::xml_text(xml_text_node) <- matsp[,2]
+    }
+    xml2::write_xml(svg, file = tmpfilesvg)
     return(tmpfilesvg)
   }
   switch(
@@ -757,6 +756,7 @@ PRISMA_save <- function(plotobj, format = 'HTML', filename = 'PRISMA2020_flowdia
     },
     "PDF" = {
       tmp_svg <- gen_tmp_svg_(plotobj)
+      message(tmp_svg)
       rsvg::rsvg_pdf(tmp_svg, paste0(filename,'.pdf'))
     },
     "PNG" = {
@@ -775,5 +775,6 @@ PRISMA_save <- function(plotobj, format = 'HTML', filename = 'PRISMA2020_flowdia
       tmp_svg <- gen_tmp_svg_(plotobj)
       rsvg::rsvg_webp(tmp_svg, paste0(filename,'.webp'))
     },
+    stop("Please choose one of the supported file types")
   )
 }

--- a/R/PRISMA_flowdiagram.R
+++ b/R/PRISMA_flowdiagram.R
@@ -14,7 +14,7 @@
 #' studies were sought.
 #' @param other Logical argument (TRUE or FALSE) specifying whether other studies 
 #' were sought.
-#' @param font The font for text in each box. The default is 'Helvetica'.
+#' @param font Theor text in each box. The default is 'Helvetica'.
 #' @param fontsize The font size for text in each box. The default is '12'.
 #' @param title_colour The colour for the upper middle title box (new studies). 
 #' The default is 'Goldenrod1'. See 'DiagrammeR' colour scheme 
@@ -65,15 +65,14 @@ PRISMA_flowdiagram <- function (data,
     return(gsub("(.)(?!$)", "\\1\n", x, perl=TRUE))
   }
 
-  id_side_label='Identification'
-  scr_side_label='Screening'
-  inc_side_label='Included'
+  id_side_label <- "Identification"
+  scr_side_label <- "Screening"
+  inc_side_label <- "Included"
 
-  id_side_label <- add_newline_between_chars_(id_side_label)
-  scr_side_label <- add_newline_between_chars_(scr_side_label)
-  inc_side_label <- add_newline_between_chars_(inc_side_label)
+  #id_side_label <- add_newline_between_chars_(id_side_label)
+  #scr_side_label <- add_newline_between_chars_(scr_side_label)
+  #inc_side_label <- add_newline_between_chars_(inc_side_label)
   
-
   #wrap exclusion reasons
   dbr_excluded[,1] <- stringr::str_wrap(dbr_excluded[,1], 
                     width = 35)
@@ -288,11 +287,11 @@ PRISMA_flowdiagram <- function (data,
   node [shape = box,
         fontsize = ", fontsize,",
         fontname = ", font, ",
-        color = ", title_colour, ",
-        labelangle = 90 ]
-  identification [color = LightSteelBlue2, label='",id_side_label,"', style = 'filled,rounded', pos='",-1.4,",",ystart+7,"!', width = 0.4, height = 1.5, tooltip = '", tooltips[20], "'];
-  screening [color = LightSteelBlue2, label='",scr_side_label,"', style = 'filled,rounded', pos='",-1.4,",",ystart+4.5,"!', width = 0.4, height = 2.5, tooltip = '", tooltips[21], "'];
-  included [color = LightSteelBlue2, label='",inc_side_label,"', style = 'filled,rounded', pos='",-1.4,",",h_adj1+0.87,"!', width = 0.4, height = ",2.5-h_adj2,", tooltip = '", tooltips[22], "'];\n
+        color = ", title_colour, "
+        ]
+  identification [color = LightSteelBlue2, label='', style = 'filled,rounded', pos='",-1.4,",",ystart+7,"!', width = 0.4, height = 1.5, tooltip = '", tooltips[20], "'];
+  screening [color = LightSteelBlue2, label='', style = 'filled,rounded', pos='",-1.4,",",ystart+4.5,"!', width = 0.4, height = 2.5, tooltip = '", tooltips[21], "'];
+  included [color = LightSteelBlue2, label='', style = 'filled,rounded', pos='",-1.4,",",h_adj1+0.87,"!', width = 0.4, height = ",2.5-h_adj2,", tooltip = '", tooltips[22], "'];\n
   ",
            previous_nodes,"
   node [shape = box,
@@ -453,65 +452,51 @@ PRISMA_flowdiagram <- function (data,
   ")
   )
   
-#   # Append in vertical text on blue bars
-#   if (paste0(previous,  other) == 'TRUETRUE'){
-#     insertJS <- function(plot){
-#       javascript <- htmltools::HTML('
-# var theDiv = document.getElementById("node1");
-# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'537\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Identification</text>";
-# var theDiv = document.getElementById("node2");
-# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'356\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Screening</text>";
-# var theDiv = document.getElementById("node3");
-# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'95\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Included</text>";
-#                               ')
-#       htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
-#     }
-#     x <- insertJS(x)
-#     } else if (paste0(previous,  other) == 'FALSETRUE'){
-#     insertJS <- function(plot){
-#       javascript <- htmltools::HTML('
-# var theDiv = document.getElementById("node1");
-# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'497\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Identification</text>";
-# var theDiv = document.getElementById("node2");
-# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'315\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Screening</text>";
-# var theDiv = document.getElementById("node3");
-# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'100\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Included</text>";
-#                               ')
-#       htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
-#     }
-#     x <- insertJS(x)
-#   } else if (paste0(previous,  other) == 'TRUEFALSE'){
-#     insertJS <- function(plot){
-#       javascript <- htmltools::HTML('
-# var theDiv = document.getElementById("node1");
-# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'536\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Identification</text>";
-# var theDiv = document.getElementById("node2");
-# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'357\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Screening</text>";
-# var theDiv = document.getElementById("node3");
-# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'95\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Included</text>";
-#                               ')
-#       htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
-#     }
-#     x <- insertJS(x)
-#   } else {
-#     insertJS <- function(plot){
-#       javascript <- htmltools::HTML('
-# var theDiv = document.getElementById("node1");
-# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'497\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Identification</text>";
-# var theDiv = document.getElementById("node2");
-# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'315\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Screening</text>";
-# var theDiv = document.getElementById("node3");
-# theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'100\' y=\'19\' font-family=\'Helvetica,sans-Serif\' font-size=\'14.00\'>Included</text>";
-#                               ')
-#       htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
-#     }
-#     x <- insertJS(x)
-#     }
+  # Append in vertical text on blue bars
+  switch (
+    paste0(previous, other),
+    'TRUETRUE' = {
+      y = '19'
+      node1x <- '537'
+      node2x <- '356'
+      node3x <- '95'
+    },
+    'FALSETRUE' = {
+      y = '19'
+      node1x <- '497'
+      node2x <- '315'
+      node3x <- '100'
+    },
+    'TRUEFALSE' = {
+      y = '19'
+      node1x <- '536'
+      node2x <- '357'
+      node3x <- '95'
+    },
+    'FALSEFALSE' = {
+      y = '19'
+      node1x <- '440'
+      node2x <- '260'
+      node3x <- '40'
+    }
+  )
+
+  insertJS_ <- function (plot) {
+    javascript <- htmltools::HTML(paste0('
+      var theDiv = document.getElementById("node1");
+      theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'',node1x,'\' y=\'',y,'\' font-family=\'',font,',sans-Serif\' font-size=\'',fontsize,'\'>',id_side_label,'</text>";
+      var theDiv = document.getElementById("node2");
+      theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'',node2x,'\' y=\'',y,'\' font-family=\'',font,',sans-Serif\' font-size=\'',fontsize,'\'>',scr_side_label,'</text>";
+      var theDiv = document.getElementById("node3");
+      theDiv.innerHTML += "<text text-anchor=\'middle\' style=\'transform: rotate(-90deg);\' x=\'',node3x,'\' y=\'',y,'\' font-family=\'',font,',sans-Serif\' font-size=\'',fontsize,'\'>',inc_side_label,'</text>";
+    '))
+    htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
+  }
+  x <- insertJS_(x)
   
   if (interactive == TRUE) {
     x <- sr_flow_interactive(x, urls, previous = previous, other = other)
   }
-  
   return(x)
 }
 
@@ -732,9 +717,11 @@ sr_flow_interactive <- function(plot,
 
 #' Save PRISMA2020 flow diagram
 #' 
-#' @description Save the html output from PRISMA_flowdiagram() to the 
+#' @description Save the output from PRISMA_flowdiagram() to the 
 #' working directory.
 #' @param plotobj A plot produced using PRISMA_flowdiagram().
+#' @param format The format to save the plot in, supports: HTML, PDF, PNG, SVG, PS and WEBP
+#' @param filename The filename to save 
 #' @return A flow diagram plot as an html file, with embedded links and 
 #' tooltips if interactive=TRUE in PRISMA_flowdiagram() and if tooltips 
 #' are provided in the data upload, respectively.
@@ -751,6 +738,42 @@ sr_flow_interactive <- function(plot,
 #' PRISMA_save(plot, format = 'pdf')
 #' }
 #' @export
-PRISMA_save <- function(plotobj){
-  htmlwidgets::saveWidget(plotobj, file="PRISMA2020_flowdiagram.html")
+PRISMA_save <- function(plotobj, format = 'HTML', filename = 'PRISMA2020_flowdiagram'){
+  gen_tmp_svg_ <- function(obj) {
+    #xpathsvg = "//*[name() = 'svg']"
+    tmpfilehtml <- tempfile(pattern = "PRISMA2020_", tmpdir = tempdir(), fileext = ".html" )
+    tmpfilesvg <- tempfile(pattern = "PRISMA2020_", tmpdir = tempdir(), fileext = ".svg" )
+    htmlwidgets::saveWidget(obj, file=tmpfilehtml)
+    htmldata <- xml2::read_html(tmpfilehtml)
+    js <- xml2::xml_find_first(htmldata,'//div[contains(@class, "grViz")]//following-sibling::script')    
+    svg <- DiagrammeRsvg::export_svg(plotobj)
+    writeLines(svg,tmpfilesvg)
+    return(tmpfilesvg)
+  }
+  switch(
+    format,
+    "HTML" = {
+      htmlwidgets::saveWidget(plotobj, file=filename)      
+    },
+    "PDF" = {
+      tmp_svg <- gen_tmp_svg_(plotobj)
+      rsvg::rsvg_pdf(tmp_svg, paste0(filename,'.pdf'))
+    },
+    "PNG" = {
+      tmp_svg <- gen_tmp_svg_(plotobj)
+      rsvg::rsvg_png(tmp_svg, paste0(filename,'.png'))
+    },
+    "SVG" = {
+      tmp_svg <- gen_tmp_svg_(plotobj)
+      rsvg::rsvg_svg(tmp_svg, paste0(filename,'.svg'))
+    },
+    "PS" = {
+      tmp_svg <- gen_tmp_svg_(plotobj)
+      rsvg::rsvg_ps(tmp_svg, paste0(filename,'.ps'))
+    },
+    "WEBP" = {
+      tmp_svg <- gen_tmp_svg_(plotobj)
+      rsvg::rsvg_webp(tmp_svg, paste0(filename,'.webp'))
+    },
+  )
 }

--- a/R/PRISMA_flowdiagram.R
+++ b/R/PRISMA_flowdiagram.R
@@ -765,7 +765,7 @@ PRISMA_save <- function(plotobj, format = 'HTML', filename = 'PRISMA2020_flowdia
     },
     "SVG" = {
       tmp_svg <- gen_tmp_svg_(plotobj)
-      xml2::write_xml(tmp_svg,paste0(filename,'.svg'))
+      xml2::write_xml(tmp_svg,file = paste0(filename,'.svg'))
     },
     "PS" = {
       tmp_svg <- gen_tmp_svg_(plotobj)

--- a/R/PRISMA_flowdiagram.R
+++ b/R/PRISMA_flowdiagram.R
@@ -60,11 +60,6 @@ PRISMA_flowdiagram <- function (data,
                                 arrow_colour = 'Black',
                                 arrow_head = 'normal',
                                 arrow_tail = 'none') {
-  
-  id_side_label <- "Identification"
-  scr_side_label <- "Screening"
-  inc_side_label <- "Included"
-  
   #wrap exclusion reasons
   dbr_excluded[,1] <- stringr::str_wrap(dbr_excluded[,1], 
                     width = 35)
@@ -446,14 +441,14 @@ PRISMA_flowdiagram <- function (data,
 
   insertJS_ <- function (plot) {
      javascript <- htmltools::HTML(paste0('
-        const nodeMap = new Map([["node1","',id_side_label,'"], ["node2","',scr_side_label,'"], ["node3","',inc_side_label,'"]]);
+        const nodeMap = new Map([["node1","',identification_text,'"], ["node2","',screening_text,'"], ["node3","',included_text,'"]]);
         for (const [node, label] of nodeMap) {
           var theDiv = document.getElementById(node);
           var theText = theDiv.querySelector("text");
           var attrX = theText.getAttribute("x");
           var attrY = theText.getAttribute("y");
-          theText.setAttribute("y",1+parseFloat(attrX))
-          theText.setAttribute("x",-1*parseFloat(attrY))
+          theText.setAttribute("y",parseFloat(attrX)+2)
+          theText.setAttribute("x",parseFloat(attrY)*-1)
           theText.setAttribute("style","transform: rotate(-90deg);")
           theText.innerHTML = label;
         }
@@ -541,6 +536,9 @@ read_PRISMAdata <- function(data){
   new_reports_text <- data[grep('new_reports', data[,1]),]$boxtext
   total_studies_text <- data[grep('total_studies', data[,1]),]$boxtext
   total_reports_text <- data[grep('total_reports', data[,1]),]$boxtext
+  identification_text <- data[grep('identification', data[,1]),]$boxtext
+  screening_text <- data[grep('screening', data[,1]),]$boxtext
+  included_text <- data[grep('included', data[,1]),]$boxtext
   
   x <- list(previous_studies = previous_studies,
            previous_reports = previous_reports,
@@ -593,6 +591,9 @@ read_PRISMAdata <- function(data){
            new_reports_text = new_reports_text,
            total_studies_text = total_studies_text,
            total_reports_text = total_reports_text,
+           identification_text = identification_text,
+           screening_text = screening_text,
+           included_text = included_text,
            tooltips = tooltips,
            urls = urls)
   
@@ -741,7 +742,7 @@ PRISMA_save <- function(plotobj, format = 'HTML', filename = 'PRISMA2020_flowdia
       attrX <- xml2::xml_attr(xml_text_node, "x")
       attrY <- xml2::xml_attr(xml_text_node, "y")
       xml2::xml_attr(xml_text_node, "x") <- as.double(attrY)*-1
-      xml2::xml_attr(xml_text_node, "y") <- as.double(attrX)+1
+      xml2::xml_attr(xml_text_node, "y") <- as.double(attrX)+2
       # libRSVG does not support css transforms, so we need to use the native SVG transform attribute
       xml2::xml_attr(xml_text_node, "transform") <- "rotate(-90)"
       xml2::xml_text(xml_text_node) <- matsp[,2]
@@ -750,7 +751,7 @@ PRISMA_save <- function(plotobj, format = 'HTML', filename = 'PRISMA2020_flowdia
     return(tmpfilesvg)
   }
   switch(
-    format,
+    toupper(format),
     "HTML" = {
       htmlwidgets::saveWidget(plotobj, file=filename)      
     },

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,105 @@
+# Utility functions for PRISMA_flowdiagram
+
+#' Generate / insert JS for labels
+#'
+#' @description Generate the javascript method to insert the side labels
+#' @param plot the plot object (without side labels)
+#' @param identification_text the text to use as the "identification" label
+#' @param screening_text the text to use as the "screening" label
+#' @param included_text the text to use as the "identification" label
+#' @return the plot object (with JS to generate side labels)
+#' @NoRd
+insertJS_ <- function (plot, identification_text, screening_text, included_text) {
+    # This JS loops through each node, and
+    # locates the relevent <text> tag containing the label
+    # The blank label is replaced with the relevent descriptive label
+    # This is done in the loop as positioning due
+    # to rotation otherwise being difficult
+    # we rotate the text and adjust the position to ensure that
+    # the now rotated text is displayed correctly
+    javascript <- htmltools::HTML(paste0('
+       const nodeMap = new Map([["node1","',identification_text,'"], ["node2","',screening_text,'"], ["node3","',included_text,'"]]);
+       for (const [node, label] of nodeMap) {
+         var theDiv = document.getElementById(node);
+         var theText = theDiv.querySelector("text");
+         var attrX = theText.getAttribute("x");
+         var attrY = theText.getAttribute("y");
+         theText.setAttribute("y",parseFloat(attrX)+2)
+         theText.setAttribute("x",parseFloat(attrY)*-1)
+         theText.setAttribute("style","transform: rotate(-90deg);")
+         theText.innerHTML = label;
+       }
+    '))
+    plot <- htmlwidgets::appendContent(plot, htmlwidgets::onStaticRenderComplete(javascript))
+    return(plot)
+}
+
+#' Calculate the correct filetime
+#'
+#' @description Work out the correct filetype to save the file as
+#' @param fn The filename (including extension)
+#' @param ft The filetype (which can be NA or NULL)
+#' @return the filetype taken from the filename, or overriden by the ft param
+#' @NoRd
+calc_filetype_ <- function(fn, ft) {
+    # if the filetype is set, return that, otherwise
+    # calculate the filetype from the extension (HTM becomes HTML)
+    if(!is.na(ft) & !is.null(ft)){
+      the_ft <- toupper(ft)
+    } else {
+      the_ft <- toupper(tools::file_ext(fn))
+      if (the_ft == 'HTM') {
+        the_ft <- 'HTML'
+      }
+    }
+    return(the_ft)
+}
+
+#' Generate a temporary SVG from a plot object
+#'
+#' @description Generate and save a temporary SVG from a plot object
+#' @param obj the plot object
+#' @return the full path to the saved SVG
+#' @NoRd
+gen_tmp_svg_ <- function(obj) {
+    # generate temporary filenames
+    tmpfilehtml <- tempfile(pattern = "PRISMA2020_", tmpdir = tempdir(), fileext = ".html" )
+    tmpfilesvg <- tempfile(pattern = "PRISMA2020_", tmpdir = tempdir(), fileext = ".svg" )
+    # save the widget as HTML and read it into a variable
+    htmlwidgets::saveWidget(obj, file=tmpfilehtml)
+    htmldata <- xml2::read_html(tmpfilehtml)
+    # extract our labelling javascript using xml_find_first and xpath
+    # it finds the first script element follwing the grViz class - this looks to be quite fragile if we change our injected JS
+    js <- xml2::xml_text(xml2::xml_find_first(htmldata,'//div[contains(@class, "grViz")]//following-sibling::script'))
+    # use DiagrammeRsvg to export an SVG from the htmlwidgets code - this uses the V8 engine in the background so takes a little bit of time to run
+    # then read the SVG's XML into a variable
+    svg <- DiagrammeRsvg::export_svg(obj)
+    svg <- xml2::read_xml(svg)
+    # we need to extract the node names and the label values from our JS, so find the appropriate part of the code (again, sensitive to script changes)
+    # we then extract the node names and labels and insert them into the SVG, in a similar manner to the original JS code
+    jsnode <- stringr::str_split(
+      stringr::str_remove_all(
+        stringr::str_match(
+          js, "const nodeMap = new Map\\(\\[(.*)\\]\\);"
+        )[1,2],
+        "\\[|\"|]"
+      ),
+      ",\\s",
+      simplify = TRUE
+    )
+    len <- length(jsnode)
+    for (i in 1:len) {
+      matsp <- stringr::str_split_fixed(jsnode[i],",",2)
+      namespace <- xml2::xml_ns(svg)
+      xml_text_node <- xml2::xml_find_first(svg, paste0('//d1:g[@id="',matsp[,1],'"]//d1:text'), namespace)
+      attrX <- xml2::xml_attr(xml_text_node, "x")
+      attrY <- xml2::xml_attr(xml_text_node, "y")
+      xml2::xml_attr(xml_text_node, "x") <- as.double(attrY)*-1
+      xml2::xml_attr(xml_text_node, "y") <- as.double(attrX)+2
+      # libRSVG does not support css transforms, so we need to use the native SVG transform attribute
+      xml2::xml_attr(xml_text_node, "transform") <- "rotate(-90)"
+      xml2::xml_text(xml_text_node) <- matsp[,2]
+    }
+    xml2::write_xml(svg, file = tmpfilesvg)
+    return(tmpfilesvg)
+}

--- a/inst/extdata/PRISMA.csv
+++ b/inst/extdata/PRISMA.csv
@@ -26,6 +26,6 @@ new_studies,node15,box10,New studies included in review,New studies included in 
 new_reports,NA,box10,Reports of new included studies,Reports of new included studies,NA,NA,xxx
 total_studies,node22,box16,Total studies included in review,Total studies included in review,Total studies included in review,total_studies.html,xxx
 total_reports,NA,box16,Reports of total included studies,Reports of total included studies,NA,NA,xxx
-identification,node1,identification,Blue identification box,NA,Blue identification box,identification.html,xxx
-screening,node2,screening,Blue screening box,NA,Blue screening box,screening.html,xxx
-included,node3,included,Blue included box,NA,Blue included box,included.html,xxx
+identification,node1,identification,Blue identification box,Identification,Blue identification box,identification.html,xxx
+screening,node2,screening,Blue screening box,Screening,Blue screening box,screening.html,xxx
+included,node3,included,Blue included box,Included,Blue included box,included.html,xxx

--- a/man/PRISMA_flowdiagram.Rd
+++ b/man/PRISMA_flowdiagram.Rd
@@ -73,7 +73,7 @@ provided.
 }
 \examples{
 \dontrun{
-data <- read.csv(file.choose());
+data <- read.csv(file.choose(), stringsAsFactors=FALSE);
 data <- read_PRISMAdata(data);
 attach(data); 
 plot <- PRISMA_flowdiagram(data,

--- a/man/PRISMA_save.Rd
+++ b/man/PRISMA_save.Rd
@@ -4,10 +4,14 @@
 \alias{PRISMA_save}
 \title{Save PRISMA2020 flow diagram}
 \usage{
-PRISMA_save(plotobj)
+PRISMA_save(plotobj, format = "HTML", filename = "PRISMA2020_flowdiagram")
 }
 \arguments{
 \item{plotobj}{A plot produced using PRISMA_flowdiagram().}
+
+\item{format}{The format to save the plot in, supports: HTML, PDF, PNG, SVG, PS and WEBP}
+
+\item{filename}{The filename to save (without extension)}
 }
 \value{
 A flow diagram plot as an html file, with embedded links and
@@ -15,7 +19,7 @@ tooltips if interactive=TRUE in PRISMA_flowdiagram() and if tooltips
 are provided in the data upload, respectively.
 }
 \description{
-Save the html output from PRISMA_flowdiagram() to the
+Save the output from PRISMA_flowdiagram() to the
 working directory.
 }
 \examples{

--- a/man/read_PRISMAdata.Rd
+++ b/man/read_PRISMAdata.Rd
@@ -17,7 +17,7 @@ Read in a template CSV containing data for the flow diagram
 }
 \examples{
 \dontrun{
-data <- read.csv(file.choose());
+data <- read.csv(file.choose(), stringsAsFactors=FALSE);
 data <- read_PRISMAdata(data);
 attach(data);
 }


### PR DESCRIPTION
I've implemented the ```PRISMA_save()``` function, in doing so I've also tidied up the javascript, such that the labels are programatically placed (which should make it play nicer with different font / font sizes - it's not perfect, but it works well with fonts up to about size 14).

key changes:

```insertJS()``` is now much tidier, as it doesn't rely on static values, using ```paste0()``` the label text is now inserted from a variable rather than being hardcoded (todo: move this to the CSV file to enable localisation).

There is now a label (a single space) inserted into the graphviz nodes for identification, screening and included, instead of the javascript inserting a new node, the existing label node is located using XPath and then the text, along with the x, y, and style attributes are set by the JS code - this means the font and size is fully controlled by arguments to PRISMA_flowdiagram and so is much more consistent.

```PRISMA_save()``` is implemented using a combination of ```xml2```,```DiagrammeRsvg```,```rsvg``` and ```htmlwidgets```. HTML is just a straightforward dump using ```htmlwidgets::saveWidget()```, although it is now possible to specify a custom filename. For the other formats (SVG, PDF, PNG, PS and WEBP), the html is saved to a temporary file using ```htmlwidgets::saveWidget()```, the JS code from earlier is extracted, from which the node names and label text is retrieved. ```DiagrammeRsvg``` is used to extract the SVG from the HTML page, and the XML is read into a variable, the retrieved node names are looped through, and the appropriate modifications to the SVG is made, thanks to ```xml2``` and XPath, this new SVG is now saved to a temporary file, which can be appropriately converted thanks to ```rsvg``` into either PDF, PNG, PS or WEBP, or saved directly as an SVG!

I've done this as a draft-PR for now, because I think multiple heads are better than one for testing!

fixes: #2