### PR TITLE
Enabled downloading of archived HTML and adjacent libraries 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,8 @@ Imports:
     webp,
     DT,
     rio,
-    tools
+    tools,
+    zip
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/PRISMA_flowdiagram.R
+++ b/R/PRISMA_flowdiagram.R
@@ -682,9 +682,10 @@ PRISMA_data <- function(data){
 #' working directory.
 #' @param plotobj A plot produced using [PRISMA_flowdiagram()].
 #' @param filename The filename to save (including extension)
-#' @param filetype The filetype to save the plot in, supports: HTML, PDF, PNG, SVG, PS and WEBP
+#' @param filetype The filetype to save the plot in, supports: HTML, ZIP, PDF, PNG, SVG, PS and WEBP
 #' (if NA, the filetype will be calculated out based on the file extension)
 #' HTML files maintain hyperlinks and tooltips
+#' The ZIP option creates an archive containing the HTML file, and supporting javascript and css files in an adjacent folder, instead of embedded base64 within the HTML file
 #' @param overwrite if TRUE, will overwrite an existing file
 #' @return the absolute filename of the saved diagram plot.
 #' @examples
@@ -704,12 +705,26 @@ PRISMA_save <- function(plotobj, filename = 'PRISMA2020_flowdiagram.html', filet
     switch(
       format_real,
       "HTML" = {
-        tmp_html <- tempfile(pattern = "PRISMA2020_", tmpdir = tempdir(), fileext = ".html" )
-        htmlwidgets::saveWidget(plotobj, file=tmp_html, title = tools::file_path_sans_ext(filename))
+        tmp_html <- tempfile(pattern = "PRISMA2020_", tmpdir=tempdir(), fileext=".html" )
+        htmlwidgets::saveWidget(plotobj, file=tmp_html, title="PRISMA2020 Flowdiagram")
         if (!(file.copy(tmp_html, filename, overwrite = TRUE))){
           stop("Error saving HTML")
         }
         file.remove(tmp_html)
+      },
+      "ZIP" = {
+        curr_wd <- getwd()
+        tmp_dir <- tempdir()
+        setwd(tmp_dir)
+        tmp_zipfile <- tempfile(pattern = "PRISMA2020_", tmpdir=tempdir(), fileext=".zip" )
+        tmp_html <- paste0(tools::file_path_sans_ext(basename(filename)),".html")
+        tmp_libdir <- paste0(tmp_html,"_files")
+        htmlwidgets::saveWidget(plotobj, file=tmp_html, libdir=tmp_libdir,selfcontained=FALSE, title="PRISMA2020 Flowdiagram")
+        zip::zip(zipfile = tmp_zipfile, files = c(tmp_html, tmp_libdir))
+        setwd(curr_wd)
+        if (!(file.copy(paste0(tmp_zipfile), filename, overwrite = TRUE))){
+          stop("Error saving ZIP File")
+        }
       },
       "PDF" = {
         tmp_svg <- PRISMA_gen_tmp_svg_(plotobj)

--- a/inst/extdata/PRISMA.csv
+++ b/inst/extdata/PRISMA.csv
@@ -5,7 +5,7 @@ previous_reports,NA,box1,Reports of studies included in previous version of revi
 NA,node6,newstud,Yellow title box; Identification of new studies via databases and registers,Identification of new studies via databases and registers,Yellow title box; Identification of new studies via databases and registers,newstud.html,0
 database_results,node7,box2,Records identified from: Databases,Databases,Records identified from: Databases,database_results.html,0
 register_results,NA,box2,Records identified from: Registers,Registers,NA,NA,0
-NA,node16,othstud,Grey title box; Identification of new studies via other methods,Identification of new studies via other methods5235325235,Grey title box; Identification of new studies via other methods,othstud.html,0
+NA,node16,othstud,Grey title box; Identification of new studies via other methods,Identification of new studies via other methods,Grey title box; Identification of new studies via other methods,othstud.html,0
 website_results,node17,box11,Records identified from: Websites,Websites,Records identified from: Websites,website_results.html,0
 organisation_results,,box11,Records identified from: Organisations,Organisations,NA,NA,0
 citations_results,NA,box11,Records identified from: Citation searching,Citation searching,NA,NA,0

--- a/inst/shiny-examples/PRISMA_flowdiagram/app.R
+++ b/inst/shiny-examples/PRISMA_flowdiagram/app.R
@@ -111,7 +111,8 @@ ui <- tagList(
                                                  downloadButton('PRISMAflowdiagramPDF', 'PDF'),
                                                  downloadButton('PRISMAflowdiagramPNG', 'PNG'),
                                                  downloadButton('PRISMAflowdiagramSVG', 'SVG'),
-                                                 downloadButton('PRISMAflowdiagramHTML', 'Interactive HTML')
+                                                 downloadButton('PRISMAflowdiagramHTML', 'Interactive HTML'),
+                                                 downloadButton('PRISMAflowdiagramZIP', 'Interactive HTML (ZIP)')
                                     ), 
                                     mainPanel(
                                       DiagrammeR::grVizOutput(outputId = "plot1", width = "100%", height = "700px"))
@@ -366,6 +367,13 @@ server <- function(input, output) {
     content = function(file){
       PRISMA2020::PRISMA_save(plot(),
                  filename = file, filetype = "html")
+    }
+  )
+  output$PRISMAflowdiagramZIP <- downloadHandler(
+    filename = "prisma.zip",
+    content = function(file){
+      PRISMA2020::PRISMA_save(plot(),
+                 filename = file, filetype = "zip")
     }
   )
 }

--- a/man/PRISMA_save.Rd
+++ b/man/PRISMA_save.Rd
@@ -16,9 +16,10 @@ PRISMA_save(
 
 \item{filename}{The filename to save (including extension)}
 
-\item{filetype}{The filetype to save the plot in, supports: HTML, PDF, PNG, SVG, PS and WEBP
+\item{filetype}{The filetype to save the plot in, supports: HTML, ZIP, PDF, PNG, SVG, PS and WEBP
 (if NA, the filetype will be calculated out based on the file extension)
-HTML files maintain hyperlinks and tooltips}
+HTML files maintain hyperlinks and tooltips
+The ZIP option creates an archive containing the HTML file, and supporting javascript and css files in an adjacent folder, instead of embedded base64 within the HTML file}
 
 \item{overwrite}{if TRUE, will overwrite an existing file}
 }


### PR DESCRIPTION
This is because html with libraries as base64 encoded strings are not always compatible with modern security policies